### PR TITLE
support llama3 flash attn varlen on Ascend NPU

### DIFF
--- a/ring_attn_ascend/__init__.py
+++ b/ring_attn_ascend/__init__.py
@@ -1,3 +1,7 @@
+from .llama3_flash_attn_varlen import (
+    llama3_flash_attn_prepare_cu_seqlens,
+    llama3_flash_attn_varlen_func,
+)
 from .ring_flash_attn import ring_flash_attn_func
 from .ring_flash_attn_varlen import ring_flash_attn_varlen_func
 from .zigzag_ring_flash_attn import zigzag_ring_flash_attn_func

--- a/ring_attn_ascend/llama3_flash_attn_varlen.py
+++ b/ring_attn_ascend/llama3_flash_attn_varlen.py
@@ -1,0 +1,371 @@
+import torch
+import torch
+try:
+    import torch_npu  # noqa: F401
+except ImportError:
+    print("Failed to import torch_npu.")
+import torch.distributed as dist
+
+from .utils import AllGatherComm as Comm
+
+
+def llama3_flash_attn_prepare_cu_seqlens(
+    cu_seqlens: torch.Tensor, causal: bool, rank: int, world_size: int
+):
+    """
+    Args:
+        cu_seqlens: torch.Tensor, the cu_seqlens of all the sequences across the ring process group.
+
+    Returns:
+        cu_seqlens_q: torch.Tensor, the cu_seqlens of the q slice for this rank.
+        cu_seqlens_k: torch.Tensor, the cu_seqlens of the k slice that the local q need. Note
+            that this may be longer than `total_seq_len // world_size`.
+        local_k_slice: slice, the slice of the k that the local q need. Note
+            that this may be longer than `total_seq_len // world_size`.
+    """
+    total_length = cu_seqlens[-1]
+    assert total_length % world_size == 0
+    length_per_rank = total_length // world_size
+    left = torch.searchsorted(cu_seqlens, rank * length_per_rank)
+    right = torch.searchsorted(cu_seqlens, (rank + 1) * length_per_rank)
+    length_per_rank = length_per_rank.item()
+
+    # after this, cu_seqlens[left:right + 1] contains all the sequence for this rank
+    if cu_seqlens[left] != rank * length_per_rank:
+        left -= 1
+    left = left.item()
+    right = right.item()
+
+    # q is always the same. just calculate the cu_seqlens for the local slice
+    cu_seqlens_q = cu_seqlens[left : right + 1].clone()
+    cu_seqlens_q -= rank * length_per_rank
+    cu_seqlens_q[0] = 0
+    cu_seqlens_q[-1] = length_per_rank
+
+    cu_seqlens_k = cu_seqlens[left : right + 1].clone()
+    if causal:
+        # when causal, we hope
+        # - the last k seq is of the same length as the last q seq
+        slice_right = (rank + 1) * length_per_rank
+        cu_seqlens_k[-1] = slice_right
+    else:
+        # when not causal, we hope
+        # - the last k is full seq
+        slice_right = cu_seqlens[right].item()
+
+    slice_left = cu_seqlens[left].item()
+    cu_seqlens_k -= slice_left
+
+    local_k_slice = slice(slice_left, slice_right)
+    return cu_seqlens_q, cu_seqlens_k, local_k_slice
+
+
+def llama3_flash_attn_varlen_forward(
+    process_group,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    heads_k_stride,
+    local_k_slice,
+    softmax_scale,
+    attn_mask,
+    dropout_p=0,
+    causal=True,
+):
+    assert causal == True, "causal==False is not supported."
+
+    out_list = []
+    softmax_max_list = []
+    softmax_sum_list = []
+
+    nheads = q.shape[1]
+    total_k, nheads_k, head_dim = k.shape
+    assert nheads_k % heads_k_stride == 0
+
+    world_size = dist.get_world_size(process_group)
+    kv_buffer = torch.empty(
+        (2, total_k * world_size, heads_k_stride, head_dim),
+        dtype=k.dtype,
+        device=k.device,
+    )
+
+    kv_buffer_copy = torch.empty_like(kv_buffer)
+
+    k_0 = k[:, :heads_k_stride].contiguous()
+    v_0 = v[:, :heads_k_stride].contiguous()
+    comm = Comm(process_group)
+
+    comm.all_gather(kv_buffer_copy[0], k_0)
+    comm.all_gather(kv_buffer_copy[1], v_0)
+
+    for i in range(0, nheads_k, heads_k_stride):
+        comm.wait()
+        kv_buffer, kv_buffer_copy = kv_buffer_copy, kv_buffer
+
+        if i < nheads_k - heads_k_stride:
+            # all_gather the next kv slice
+            kv_slice_left = i + heads_k_stride
+            kv_slice_right = kv_slice_left + heads_k_stride
+            send_k = k[:, kv_slice_left:kv_slice_right].contiguous()
+            send_v = v[:, kv_slice_left:kv_slice_right].contiguous()
+            comm.all_gather(kv_buffer_copy[0], send_k)
+            comm.all_gather(kv_buffer_copy[1], send_v)
+
+        q_i = q[:, i * nheads // nheads_k : (i + heads_k_stride) * nheads // nheads_k]
+        k_i = kv_buffer[0][local_k_slice]
+        v_i = kv_buffer[1][local_k_slice]
+
+        outputs = torch_npu.npu_fusion_attention(
+            q_i,
+            k_i,
+            v_i,
+            head_num=q_i.shape[1],
+            input_layout="TND",
+            atten_mask=attn_mask,
+            scale=softmax_scale,
+            actual_seq_qlen=tuple(cu_seqlens_q[1:].cpu().numpy().tolist()),
+            actual_seq_kvlen=tuple(cu_seqlens_k[1:].cpu().numpy().tolist()),
+            sparse_mode=3,
+            keep_prob=1.0-dropout_p,
+        )
+
+        out, softmax_max, softmax_sum, _, _, _, _ = outputs
+
+        out_list.append(out)
+        softmax_max_list.append(softmax_max)
+        softmax_sum_list.append(softmax_sum)
+
+    out = torch.cat(out_list, dim=1)
+    softmax_max = torch.cat(softmax_max_list, dim=-2)
+    softmax_sum = torch.cat(softmax_sum_list, dim=-2)
+    return out, softmax_max, softmax_sum
+
+
+def llama3_flash_attn_varlen_backward(
+    process_group,
+    dout,
+    q,
+    k,
+    v,
+    out,
+    softmax_max,
+    softmax_sum,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    heads_k_stride,
+    local_k_slice,
+    softmax_scale,
+    attn_mask,
+    dropout_p=0,
+    causal=True,
+):
+    nheads = q.shape[1]
+    total_k, nheads_k, head_dim = k.shape
+    assert nheads_k % heads_k_stride == 0
+
+    world_size = dist.get_world_size(process_group)
+    kv_buffer = torch.empty(
+        (2, total_k * world_size, heads_k_stride, head_dim),
+        dtype=k.dtype,
+        device=k.device,
+    )
+    kv_buffer_copy = torch.empty_like(kv_buffer)
+
+    dkv_buffer = torch.empty(
+        (2, total_k * world_size, heads_k_stride, head_dim),
+        dtype=k.dtype,
+        device=k.device,
+    )
+
+    if heads_k_stride != nheads_k:
+        kv_contiguous_buffer = torch.empty(
+            (2, total_k, heads_k_stride, head_dim),
+            dtype=k.dtype,
+            device=k.device,
+        )
+
+    dq = torch.empty_like(q)
+    dk = torch.empty_like(k)
+    dv = torch.empty_like(v)
+
+    comm = Comm(process_group)
+
+    k_0 = k[:, :heads_k_stride].contiguous()
+    v_0 = v[:, :heads_k_stride].contiguous()
+    comm.all_gather(kv_buffer_copy[0], k_0)
+    comm.all_gather(kv_buffer_copy[1], v_0)
+
+    for i in range(0, nheads_k, heads_k_stride):
+        dkv_buffer.zero_()
+
+        q_slice = slice(
+            i * nheads // nheads_k, (i + heads_k_stride) * nheads // nheads_k
+        )
+        q_i = q[:, q_slice]
+        dout_i = dout[:, q_slice]
+        out_i = out[:, q_slice]
+
+        softmax_max_i = softmax_max[:, q_slice].contiguous()
+        softmax_sum_i = softmax_sum[:, q_slice].contiguous()
+
+        comm.wait()
+        kv_buffer, kv_buffer_copy = kv_buffer_copy, kv_buffer
+
+        if i < nheads_k - heads_k_stride:
+            # all_gather the next kv slice
+            kv_slice_left = i + heads_k_stride
+            kv_slice_right = kv_slice_left + heads_k_stride
+            send_k = k[:, kv_slice_left:kv_slice_right].contiguous()
+            send_v = v[:, kv_slice_left:kv_slice_right].contiguous()
+            comm.all_gather(kv_buffer_copy[0], send_k)
+            comm.all_gather(kv_buffer_copy[1], send_v)
+
+        k_i = kv_buffer[0][local_k_slice]
+        v_i = kv_buffer[1][local_k_slice]
+
+        attn_grad_outs = torch_npu.npu_fusion_attention_grad(
+            q_i,
+            k_i,
+            v_i,
+            dout_i,
+            head_num=q_i.shape[1],
+            input_layout="TND",
+            atten_mask=attn_mask,
+            softmax_max=softmax_max_i,
+            softmax_sum=softmax_sum_i,
+            attention_in=out_i,
+            scale_value=softmax_scale,
+            actual_seq_qlen=tuple(cu_seqlens_q[1:].cpu().numpy().tolist()),
+            actual_seq_kvlen=tuple(cu_seqlens_k[1:].cpu().numpy().tolist()),
+            sparse_mode=3,
+            keep_prob=1.0-dropout_p,
+        )
+
+        dq[:, q_slice] = attn_grad_outs[0]                  # dq_i
+        dkv_buffer[0][local_k_slice] = attn_grad_outs[1]    # dk_i
+        dkv_buffer[1][local_k_slice] = attn_grad_outs[2]    # dv_i
+
+        if heads_k_stride != nheads_k:
+            # reduce_scatter needs contiguous buffer
+            dk_i = kv_contiguous_buffer[0]
+            dv_i = kv_contiguous_buffer[1]
+        else:
+            dk_i = dk
+            dv_i = dv
+
+        dist.reduce_scatter_tensor(dk_i, dkv_buffer[0], group=process_group)
+        dist.reduce_scatter_tensor(dv_i, dkv_buffer[1], group=process_group)
+
+        if heads_k_stride != nheads_k:
+            dk[:, i : i + heads_k_stride] = dk_i
+            dv[:, i : i + heads_k_stride] = dv_i
+
+    return dq, dk, dv
+
+
+class Llama3FlashAttnVarlenFunc(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        heads_k_stride,
+        local_k_slice,
+        dropout_p,
+        softmax_scale=None,
+        attn_mask=None,
+        causal=True,
+        group=None,
+    ):
+        if softmax_scale is None:
+            softmax_scale = q.shape[-1] ** (-0.5)
+
+        if causal and attn_mask is None:
+            # Ref: https://www.hiascend.com/document/detail/zh/Pytorch/600/apiref/apilist/ptaoplist_000156.html
+            attn_mask = torch.triu(torch.ones([2048, 2048], device=q.device), diagonal=1).bool()
+        
+        k = k.contiguous()
+        v = v.contiguous()
+        out, softmax_max, softmax_sum = llama3_flash_attn_varlen_forward(
+            group,
+            q,
+            k,
+            v,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            heads_k_stride,
+            local_k_slice,
+            softmax_scale=softmax_scale,
+            attn_mask=attn_mask,
+            dropout_p=dropout_p,
+            causal=causal,
+        )
+        # this should be out_padded
+        ctx.save_for_backward(q, k, v, out, softmax_max, softmax_sum, cu_seqlens_q, cu_seqlens_k)
+        ctx.heads_k_stride = heads_k_stride
+        ctx.local_k_slice = local_k_slice
+        ctx.dropout_p = dropout_p
+        ctx.softmax_scale = softmax_scale
+        ctx.attn_mask = attn_mask
+        ctx.causal = causal
+        ctx.group = group
+        return out, softmax_max, softmax_sum
+
+    @staticmethod
+    def backward(ctx, dout, *args):
+        q, k, v, out, softmax_max, softmax_sum, cu_seqlens_q, cu_seqlens_k = ctx.saved_tensors
+        dq, dk, dv = llama3_flash_attn_varlen_backward(
+            ctx.group,
+            dout,
+            q,
+            k,
+            v,
+            out,
+            softmax_max,
+            softmax_sum,
+            cu_seqlens_q,
+            cu_seqlens_k,
+            ctx.heads_k_stride,
+            ctx.local_k_slice,
+            softmax_scale=ctx.softmax_scale,
+            attn_mask=ctx.attn_mask,
+            dropout_p=ctx.dropout_p,
+            causal=ctx.causal,
+        )
+
+        return (dq, dk, dv) + (None,) * 15
+
+
+def llama3_flash_attn_varlen_func(
+    q,
+    k,
+    v,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    heads_k_stride,
+    local_k_slice,
+    dropout_p=0.0,
+    softmax_scale=None,
+    attn_mask=None,
+    causal=False,
+    group=None,
+):
+    return Llama3FlashAttnVarlenFunc.apply(
+        q,
+        k,
+        v,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        heads_k_stride,
+        local_k_slice,
+        dropout_p,
+        softmax_scale,
+        attn_mask,
+        causal,
+        group,
+    )

--- a/ring_attn_ascend/ring_flash_attn_varlen.py
+++ b/ring_attn_ascend/ring_flash_attn_varlen.py
@@ -94,7 +94,7 @@ def ring_flash_attn_varlen_forward(
     dropout_p=0,
     causal=True,
 ):
-    assert causal == True, "causal==false is not supported."
+    assert causal == True, "causal==False is not supported."
 
     comm = RingComm(process_group)
     
@@ -230,7 +230,7 @@ class RingFlashAttnVarlenFunc(torch.autograd.Function):
 
         if causal and attn_mask is None:
             # Ref: https://www.hiascend.com/document/detail/zh/Pytorch/600/apiref/apilist/ptaoplist_000156.html
-            attn_mask = torch.triu(torch.ones([2048, 2048]), diagonal=1).bool().to(q.device)
+            attn_mask = torch.triu(torch.ones([2048, 2048], device=q.device), diagonal=1).bool()
 
         k = k.contiguous()
         v = v.contiguous()

--- a/test/test_llama3_flash_attn_varlen_func.py
+++ b/test/test_llama3_flash_attn_varlen_func.py
@@ -1,0 +1,132 @@
+"""
+torchrun --nproc_per_node=8 test_llama3_flash_attn_varlen_func.py
+"""
+import torch
+try:
+    import torch_npu  # noqa: F401
+except ImportError:
+    print("Failed to import torch_npu.")
+import torch.distributed as dist
+
+from ring_attn_ascend import (
+    llama3_flash_attn_prepare_cu_seqlens,
+    llama3_flash_attn_varlen_func,
+)
+from utils import log, set_seed
+
+
+if __name__ == "__main__":
+    dist.init_process_group("hccl")
+    rank = dist.get_rank()
+    set_seed(rank)
+    world_size = dist.get_world_size()
+    dtype = torch.bfloat16
+    device = torch.device(f"npu:{rank}")
+
+    nheads = 5
+    d = 8
+    dropout_p = 0
+    causal = True
+
+    cu_seqlens = [0, 120, 1248, 4232]
+    cu_seqlens_tensor = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+    total_length = cu_seqlens[-1]
+    local_length = total_length // world_size
+
+    assert cu_seqlens_tensor[-1] % world_size == 0
+    assert d % 8 == 0
+
+    q = torch.randn(total_length, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    k = torch.randn(total_length, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    v = torch.randn(total_length, nheads, d, device=device, dtype=dtype, requires_grad=True)
+    dist.broadcast(q, src=0)
+    dist.broadcast(k, src=0)
+    dist.broadcast(v, src=0)
+
+    dout = torch.randn(total_length, nheads, d, device=device, dtype=dtype)
+    dist.broadcast(dout, src=0)
+
+    local_q = q[rank * local_length : (rank + 1) * local_length].detach().clone()
+    local_k = k[rank * local_length : (rank + 1) * local_length].detach().clone()
+    local_v = v[rank * local_length : (rank + 1) * local_length].detach().clone()
+    local_q.requires_grad = True
+    local_k.requires_grad = True
+    local_v.requires_grad = True
+    local_dout = dout[rank * local_length : (rank + 1) * local_length].detach().clone()
+
+    dist.barrier()
+    if rank == 0:
+        print("#" * 30)
+        print("# forward:")
+        print("#" * 30)
+
+    attn_mask = torch.triu(torch.ones([2048, 2048], device=q.device), diagonal=1).bool()
+    out, _, _, _, _, _, _ = torch_npu.npu_fusion_attention(
+        q,
+        k,
+        v,
+        head_num=q.shape[1],
+        input_layout="TND",
+        atten_mask=attn_mask,
+        scale=d ** (-0.5),
+        actual_seq_qlen=tuple(cu_seqlens_tensor[1:].cpu().numpy().tolist()),
+        actual_seq_kvlen=tuple(cu_seqlens_tensor[1:].cpu().numpy().tolist()),
+        sparse_mode=3,
+        keep_prob=1.0-dropout_p,
+    )
+
+    local_out = out[rank * local_length : (rank + 1) * local_length]
+
+    (
+        local_cu_seqlens_q,
+        local_cu_seqlens_k,
+        local_k_slice,
+    ) = llama3_flash_attn_prepare_cu_seqlens(
+        cu_seqlens_tensor,
+        causal=causal,
+        rank=rank,
+        world_size=world_size,
+    )
+
+    llama3_out, _, _ = llama3_flash_attn_varlen_func(
+        local_q,
+        local_k,
+        local_v,
+        local_cu_seqlens_q,
+        local_cu_seqlens_k,
+        heads_k_stride=1,
+        local_k_slice=local_k_slice,
+        dropout_p=dropout_p,
+        causal=causal,
+    )
+
+    log("out", out, rank0_only=True)
+    log("out diff", local_out - llama3_out)
+
+    dist.barrier()
+    if rank == 0:
+        print("#" * 30)
+        print("# backward:")
+        print("#" * 30)
+
+    out.backward(dout)
+    dq = q.grad
+    dk = k.grad
+    dv = v.grad
+    local_dq = dq[rank * local_length : (rank + 1) * local_length]
+    local_dk = dk[rank * local_length : (rank + 1) * local_length]
+    local_dv = dv[rank * local_length : (rank + 1) * local_length]
+
+    llama3_out.backward(local_dout)
+    llama3_dq = local_q.grad
+    llama3_dk = local_k.grad
+    llama3_dv = local_v.grad
+
+    log("local_dq", local_dq[:, 0])
+    log("local_dk", local_dk[:, 1])
+    log("local_dv", local_dv[:, 2])
+    log("dq diff", local_dq[:, 0] - llama3_dq[:, 0])
+    log("dk diff", local_dk[:, 1] - llama3_dk[:, 1])
+    log("dv diff", local_dv[:, 2] - llama3_dv[:, 2])
+
+    dist.destroy_process_group()

--- a/test/test_ring_flash_attn_varlen_func.py
+++ b/test/test_ring_flash_attn_varlen_func.py
@@ -94,7 +94,7 @@ if __name__ == "__main__":
         print("# forward:")
         print("#" * 30)
 
-    attn_mask = torch.triu(torch.ones([2048, 2048]), diagonal=1).bool().to(q.device)
+    attn_mask = torch.triu(torch.ones([2048, 2048], device=q.device), diagonal=1).bool()
     out, softmax_max, softmax_sum, _, _, _, _ = torch_npu.npu_fusion_attention(
         q,
         k,


### PR DESCRIPTION
* 在 Ascend NPU 上支持 llama3 flash attn varlen 功能
* 将 `attn_mask = torch.triu(torch.ones([2048, 2048]), diagonal=1).bool().to(q.device)` 改为 `attn_mask = torch.triu(torch.ones([2048, 2048], device=q.device), diagonal=1).bool()`  以避免过多的 host 内存开销。在某些场景下前者会不断申请 host 内存，导致 host 内存不足使得程序退出。